### PR TITLE
Try to preserve sourcemaps, if present

### DIFF
--- a/cajon.js
+++ b/cajon.js
@@ -1950,6 +1950,7 @@ java, requirejs, document */
         exportsRegExp = /exports\s*=\s*/,
         exportsPropRegExp = /exports\.\S+\s*=\s*/,
         sourceUrlRegExp = /\/\/@\s+sourceURL=/,
+        sourceMappingUrlRegExp = /(\/\/#\s+sourceMappingURL=[^\n\r]*)/g,
         progIds = ['Msxml2.XMLHTTP', 'Microsoft.XMLHTTP', 'Msxml2.XMLHTTP.4.0'],
         hasLocation = typeof location !== 'undefined' && location.href,
         defaultProtocol = hasLocation && location.protocol && location.protocol.replace(/\:/, ''),
@@ -2123,7 +2124,7 @@ java, requirejs, document */
                 //Determine if a wrapper is needed. First strip out comments.
                 //This is not bulletproof, but it is good enough for elminating
                 //false positives from comments.
-                var shimConfig, sourceUrl,
+                var shimConfig, sourceMappingUrl, sourceUrl,
                     temp = content.replace(commentRegExp, '');
 
                 if ((!context.config.shim || !hasProp(context.config.shim, moduleName)) &&
@@ -2131,7 +2132,7 @@ java, requirejs, document */
                     exportsRegExp.test(temp) || exportsPropRegExp.test(temp))) {
                     content = 'define(function(require, exports, module) {' +
                               'var __filename = module.uri || "", ' +
-                              '__dirname = __filename.substring(0, __filename.lastIndexOf("/") + 1);\n' +
+                              '__dirname = __filename.substring(0, __filename.lastIndexOf("/") + 1);' +
                               content +
                               '\n});\n';
                 }
@@ -2151,6 +2152,13 @@ java, requirejs, document */
                             content += '\nwindow.' + shimConfig.exports + ' = ' + shimConfig.exports + ';\n';
                         }
                     }
+                }
+
+                // If a sourceMappingURL is present, move it to the end.
+                sourceMappingUrl = content.match(sourceMappingUrlRegExp);
+                if (sourceMappingUrl) {
+                    content = content.replace(sourceMappingUrlRegExp, '');
+                    content += '\n' + sourceMappingUrl;
                 }
 
                 //Add sourceURL, but only if one is not already there.

--- a/tools/c.js
+++ b/tools/c.js
@@ -14,6 +14,7 @@ java, requirejs, document */
         exportsRegExp = /exports\s*=\s*/,
         exportsPropRegExp = /exports\.\S+\s*=\s*/,
         sourceUrlRegExp = /\/\/@\s+sourceURL=/,
+        sourceMappingUrlRegExp = /(\/\/#\s+sourceMappingURL=[^\n\r]*)/g,
         progIds = ['Msxml2.XMLHTTP', 'Microsoft.XMLHTTP', 'Msxml2.XMLHTTP.4.0'],
         hasLocation = typeof location !== 'undefined' && location.href,
         defaultProtocol = hasLocation && location.protocol && location.protocol.replace(/\:/, ''),
@@ -187,7 +188,7 @@ java, requirejs, document */
                 //Determine if a wrapper is needed. First strip out comments.
                 //This is not bulletproof, but it is good enough for elminating
                 //false positives from comments.
-                var shimConfig, sourceUrl,
+                var shimConfig, sourceMappingUrl, sourceUrl,
                     temp = content.replace(commentRegExp, '');
 
                 if ((!context.config.shim || !hasProp(context.config.shim, moduleName)) &&
@@ -195,7 +196,7 @@ java, requirejs, document */
                     exportsRegExp.test(temp) || exportsPropRegExp.test(temp))) {
                     content = 'define(function(require, exports, module) {' +
                               'var __filename = module.uri || "", ' +
-                              '__dirname = __filename.substring(0, __filename.lastIndexOf("/") + 1);\n' +
+                              '__dirname = __filename.substring(0, __filename.lastIndexOf("/") + 1);' +
                               content +
                               '\n});\n';
                 }
@@ -215,6 +216,13 @@ java, requirejs, document */
                             content += '\nwindow.' + shimConfig.exports + ' = ' + shimConfig.exports + ';\n';
                         }
                     }
+                }
+
+                // If a sourceMappingURL is present, move it to the end.
+                sourceMappingUrl = content.match(sourceMappingUrlRegExp);
+                if (sourceMappingUrl) {
+                    content = content.replace(sourceMappingUrlRegExp, '');
+                    content += '\n' + sourceMappingUrl;
                 }
 
                 //Add sourceURL, but only if one is not already there.


### PR DESCRIPTION
This PR makes two changes:

1. Remove the newline after the CommonJS wrapper prefix. Due to the newline, all the mappings in the sourcemap are off by one line.

2. Move the `//# sourceMappingURL=...`, (if present) to after the CommonJS wrapper suffix. If this line is not at the end of the file, the UA typically ignores it, so no source maps are loaded.

